### PR TITLE
[FIX]: Arruma duplicidade de planos

### DIFF
--- a/assinaturaMicroservice/src/main/java/com/assinaturamicroservice/assinaturaMicroservice/domain/assinatura/Plan.java
+++ b/assinaturaMicroservice/src/main/java/com/assinaturamicroservice/assinaturaMicroservice/domain/assinatura/Plan.java
@@ -16,7 +16,7 @@ public class Plan {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
-    @Column(unique = true, length = 128)
+    @Column(length = 128)
     private String name;
 
     @Column(length = 4096)

--- a/assinaturaMicroservice/src/main/resources/application.properties
+++ b/assinaturaMicroservice/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.h2.console.enabled=true
 
 
 # Outras configuracoes (Deve ser create na primeira vez e none depois )
-spring.jpa.hibernate.ddl-auto= update
+spring.jpa.hibernate.ddl-auto= create 
 
 
 # Swagger config


### PR DESCRIPTION
Nesse PR eu arrumei o erro de duplicidade.

**Exemplo:**

- Cria plano um  "X" = **Sucesso**
- Apaga o plano "X" = **Plano apagado com sucesso**
- Cria um plano com o mesmo nome do plano "X" = **Erro(Duplicado)**